### PR TITLE
Fix undeclared global variable 'player' warning

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -124,7 +124,7 @@ if minetest.get_modpath("hudbars") ~= nil and stamina then
 		player_stamina, player_stamina,
 		false, "%s: %.1f/%.1f")
 	hudbars = true
-	hb.hide_hudbar(player, "stamina")
+	hb.hide_hudbar(nil, "stamina")
 end
 
 minetest.register_on_joinplayer(function(player)


### PR DESCRIPTION
Not sure if this is the best/right way to do this. But I simply replaced ***player*** parameter with ***nil***. I had previously tried moving the whole line to the ***register_on_joinplayer*** section, but then the bar wasn't hidden initially.