### PR TITLE
fix crash on unknown node

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -173,7 +173,10 @@ minetest.register_globalstep(function(dtime)
           hunger = tonumber(player:get_attribute("hunger_ng:hunger"))
         end
         if ground ~= nil then
-          walkable = minetest.registered_nodes[ground.name].walkable
+          local ground_def = minetest.registered_nodes[ground.name]
+          if ground_def then
+            walkable = minetest.registered_nodes[ground.name].walkable
+          end
         end
         if player_stamina > 0 and hunger > 6 and walkable then
           start_sprint(player)


### PR DESCRIPTION
This will fix a crash in occasional situations where node could not be obtained (possibly due to the node being an unknown node, or other unknown reasons). This should fix <https://github.com/minetest-mods/hbsprint/issues/10> (see <https://github.com/minetest-mods/hbsprint/issues/10#issuecomment-375918960>). More testing may be needed (this change will be applied to my server so I will post any new info), but the fix seems fairly straightforward.