### PR TITLE
Improve stamina replenishment

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -90,7 +90,8 @@ end
 
 local function replenish_stamina(player)
   local player_stamina = player:get_meta():get_float("hbsprint:stamina")
-  if player_stamina < 20 then
+  local ctrl = player:get_player_control()
+  if player_stamina < 20 and not ctrl.jump then
     player_stamina = math.min(20, player_stamina + stamina_heal)
     player:get_meta():set_float("hbsprint:stamina", player_stamina)
   end

--- a/init.lua
+++ b/init.lua
@@ -10,6 +10,7 @@ local dir           = minetest.is_yes(setting_get("sprint_forward_only", "false"
 local particles     = tonumber(setting_get("sprint_particles", "2"))
 local stamina       = minetest.is_yes(setting_get("sprint_stamina", "true"))
 local stamina_drain = tonumber(setting_get("sprint_stamina_drain", "2"))
+local stamina_heal  = tonumber(setting_get("sprint_stamina_heal", "2"))
 local replenish     = tonumber(setting_get("sprint_stamina_replenish", "2"))
 local starve        = minetest.is_yes(setting_get("sprint_starve", "true"))
 local starve_drain  = tonumber(setting_get("sprint_starve_drain", "0.5"))
@@ -90,7 +91,7 @@ end
 local function replenish_stamina(player)
   local player_stamina = player:get_meta():get_float("hbsprint:stamina")
   if player_stamina < 20 then
-    player_stamina = math.min(20, player_stamina + stamina_drain)
+    player_stamina = math.min(20, player_stamina + stamina_heal)
     player:get_meta():set_float("hbsprint:stamina", player_stamina)
   end
   if mod_hudbars then

--- a/init.lua
+++ b/init.lua
@@ -11,6 +11,7 @@ local particles     = tonumber(setting_get("sprint_particles", "2"))
 local stamina       = minetest.is_yes(setting_get("sprint_stamina", "true"))
 local stamina_drain = tonumber(setting_get("sprint_stamina_drain", "2"))
 local stamina_heal  = tonumber(setting_get("sprint_stamina_heal", "2"))
+local standing      = tonumber(setting_get("sprint_stamina_standing", "2.5"))
 local replenish     = tonumber(setting_get("sprint_stamina_replenish", "2"))
 local starve        = minetest.is_yes(setting_get("sprint_starve", "true"))
 local starve_drain  = tonumber(setting_get("sprint_starve_drain", "0.5"))
@@ -92,7 +93,11 @@ local function replenish_stamina(player)
   local player_stamina = player:get_meta():get_float("hbsprint:stamina")
   local ctrl = player:get_player_control()
   if player_stamina < 20 and not ctrl.jump then
-    player_stamina = math.min(20, player_stamina + stamina_heal)
+    if not ctrl.right and not ctrl.left and not ctrl.down and not ctrl.up and not ctrl.LMB and not ctrl.RMB then
+      player_stamina = math.min(20, player_stamina + standing)
+    else
+      player_stamina = math.min(20, player_stamina + stamina_heal)
+    end
     player:get_meta():set_float("hbsprint:stamina", player_stamina)
   end
   if mod_hudbars then

--- a/settingtypes.txt
+++ b/settingtypes.txt
@@ -19,6 +19,9 @@ sprint_stamina_drain (Stamina drain) float 2
 #The amount of stamina to heal while not sprinting
 sprint_stamina_heal (Stamina heal) float 2
 
+#The amount of stamina to heal while not moving or taking any actions
+sprint_stamina_standing (Stamina heal) float 2.5
+
 #The amount of seconds before starting to replenish stamina
 sprint_stamina_replenish (Stamina replenish) float 2
 

--- a/settingtypes.txt
+++ b/settingtypes.txt
@@ -16,6 +16,9 @@ sprint_stamina (Stamina) bool true
 #The amount of stamina to drain while sprinting
 sprint_stamina_drain (Stamina drain) float 2
 
+#The amount of stamina to heal while not sprinting
+sprint_stamina_heal (Stamina heal) float 2
+
 #The amount of seconds before starting to replenish stamina
 sprint_stamina_replenish (Stamina replenish) float 2
 


### PR DESCRIPTION
This does 3 related things.

1. This adds the `sprint_stamina_heal` setting which configures the amount of stamina to heal instead of relying on the value of `sprint_stamina_drain`. This is useful in the event someone wants to configure them differently. By default it has the same value as `sprint_stamina_drain` of `2`.
2. This prevents the stamina from replenishing while jumping, this just seems to make sense to me.
3. This adds the `sprint_stamina_standing` setting which configures the amount of stamina to heal when not moving or taking any actions. I set it by default to `2.5` to be a little bit more than `sprint_stamina_heal` which is now only used when moving or taking actions.

I am not sure of the setting names, better suggestions are appreciated.