### PR TITLE
Only drain stamina when moving.

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -199,7 +199,7 @@ local function sprint_step(player, dtime)
   if dir then
     key_press = ctrl.aux1 and ctrl.up and not ctrl.left and not ctrl.right
   else
-    key_press = ctrl.aux1
+    key_press = ctrl.aux1 and (ctrl.up or ctrl.left or ctrl.right or crtl.down)
   end
 
   if not key_press then


### PR DESCRIPTION
I noticed that when `sprint_forward_only` is disabled and the player presses the use key to sprint while not moving it will still drain stamina.

I changed it so the player sprints only when pressing the use key and at least one directional key.