### PR TITLE
Fix typo.

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -199,7 +199,7 @@ local function sprint_step(player, dtime)
   if dir then
     key_press = ctrl.aux1 and ctrl.up and not ctrl.left and not ctrl.right
   else
-    key_press = ctrl.aux1 and (ctrl.up or ctrl.left or ctrl.right or crtl.down)
+    key_press = ctrl.aux1 and (ctrl.up or ctrl.left or ctrl.right or ctrl.down)
   end
 
   if not key_press then


### PR DESCRIPTION
I'm terribly sorry, but this typo was accidentally included in PR https://github.com/minetest-mods/hbsprint/pull/23.

I'm not sure why it didn't crash at first.